### PR TITLE
Change the name (Read the Description)

### DIFF
--- a/views/about.jade
+++ b/views/about.jade
@@ -71,7 +71,7 @@ block content
 		li
 			a(href="https://jqueryui.com/") jQuery UI
 		li
-			a(href="http://getbootstrap.com/") Twitter Bootstrap
+			a(href="http://getbootstrap.com/") Bootstrap
 		li
 			a(href="https://fortawesome.github.io/Font-Awesome/") Font Awesome
 		li


### PR DESCRIPTION
If we want to use Bootstrap, we should really read the docs first.
According to Bootstrap's docs (https://github.com/twbs/bootstrap/blob/master/docs/about.html)
The termage "Twitter Bootstrap" is incorrect, and should only be called "Bootstrap" or "B".
Oh well...
